### PR TITLE
Fix Tkinter DPI handling on Windows

### DIFF
--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -69,6 +69,44 @@ class GUIDialogHandler:
             # Don't fall back to terminal in MCP context - just report the error
             raise UserPromptError(f"GUI dialog failed: {e}. Ensure osascript (macOS), zenity (Linux), or tkinter (Windows) is available.")
 
+    def _enable_windows_dpi_awareness(self) -> None:
+        """Enable crisp rendering for Windows dialogs on scaled displays."""
+        try:
+            import ctypes
+
+            try:
+                # Prefer per-monitor awareness on modern Windows versions.
+                ctypes.windll.shcore.SetProcessDpiAwareness(2)
+                return
+            except Exception:
+                pass
+
+            try:
+                ctypes.windll.user32.SetProcessDPIAware()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    def _configure_windows_tk_scaling(self, root) -> None:
+        """Match Tk scaling to the current monitor DPI when available."""
+        try:
+            import ctypes
+
+            dpi = 0
+            try:
+                dpi = ctypes.windll.user32.GetDpiForWindow(root.winfo_id())
+            except Exception:
+                try:
+                    dpi = root.winfo_fpixels("1i")
+                except Exception:
+                    dpi = 0
+
+            if dpi:
+                root.tk.call("tk", "scaling", float(dpi) / 72.0)
+        except Exception:
+            pass
+
     async def _macos_dialog(self, question: str, timeout: int) -> Optional[str]:
         """macOS dialog using osascript with custom Cursor icon."""
         
@@ -153,10 +191,12 @@ class GUIDialogHandler:
         try:
             import tkinter as tk
             from tkinter import simpledialog
-            import os
-            
+
+            self._enable_windows_dpi_awareness()
+
             # Create a simple dialog using tkinter
             root = tk.Tk()
+            self._configure_windows_tk_scaling(root)
             root.withdraw()  # Hide the main window
             
             # Try to set custom icon from PNG (converted to ICO)

--- a/tests/test_windows_dpi.py
+++ b/tests/test_windows_dpi.py
@@ -1,0 +1,104 @@
+"""Tests for Windows-specific DPI handling."""
+import asyncio
+import sys
+import types
+
+from ask_human_for_context_mcp.server import GUIDialogHandler
+
+
+def test_enable_windows_dpi_awareness_prefers_shcore(monkeypatch):
+    """Use per-monitor DPI awareness when the API is available."""
+
+    calls = []
+
+    class FakeShcore:
+        def SetProcessDpiAwareness(self, value):
+            calls.append(("shcore", value))
+
+    class FakeUser32:
+        def SetProcessDPIAware(self):
+            calls.append(("user32", None))
+
+    fake_ctypes = types.SimpleNamespace(
+        windll=types.SimpleNamespace(shcore=FakeShcore(), user32=FakeUser32())
+    )
+
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+    handler = GUIDialogHandler()
+    handler._enable_windows_dpi_awareness()
+
+    assert calls == [("shcore", 2)]
+
+
+def test_configure_windows_tk_scaling_uses_window_dpi(monkeypatch):
+    """Scale Tk based on the monitor DPI reported by Windows."""
+
+    calls = []
+
+    class FakeUser32:
+        def GetDpiForWindow(self, hwnd):
+            assert hwnd == 123
+            return 120
+
+    fake_ctypes = types.SimpleNamespace(
+        windll=types.SimpleNamespace(user32=FakeUser32())
+    )
+
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+    class FakeRoot:
+        def __init__(self):
+            self.tk = types.SimpleNamespace(call=lambda *args: calls.append(args))
+
+        def winfo_id(self):
+            return 123
+
+    handler = GUIDialogHandler()
+    handler._configure_windows_tk_scaling(FakeRoot())
+
+    assert calls == [("tk", "scaling", 120 / 72)]
+
+
+def test_windows_dialog_applies_dpi_setup(monkeypatch):
+    """Initialize DPI handling before showing the Tk dialog."""
+
+    events = []
+
+    class FakeRoot:
+        def withdraw(self):
+            events.append("withdraw")
+
+        def destroy(self):
+            events.append("destroy")
+
+    fake_root = FakeRoot()
+
+    fake_tk = types.ModuleType("tkinter")
+    fake_tk.Tk = lambda: fake_root
+    fake_tk.simpledialog = types.SimpleNamespace(
+        askstring=lambda title, question: events.append(("askstring", title, question)) or "ok"
+    )
+
+    monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
+
+    handler = GUIDialogHandler()
+    monkeypatch.setattr(
+        handler, "_enable_windows_dpi_awareness", lambda: events.append("enable-dpi")
+    )
+    monkeypatch.setattr(
+        handler, "_configure_windows_tk_scaling", lambda root: events.append(("scale", root))
+    )
+    monkeypatch.setattr(handler, "_set_windows_icon", lambda root: events.append(("icon", root)))
+
+    result = asyncio.run(handler._windows_dialog("Question?", 10))
+
+    assert result == "ok"
+    assert events == [
+        "enable-dpi",
+        ("scale", fake_root),
+        "withdraw",
+        ("icon", fake_root),
+        ("askstring", "🤖 Cursor AI Assistant", "Question?"),
+        "destroy",
+    ]


### PR DESCRIPTION
Fix blurry Windows Tkinter dialogs on scaled displays by enabling DPI awareness before creating the Tk root window and applying Tk scaling from the current monitor DPI.

- add Windows DPI-awareness setup for the Tkinter dialog path
- scale Tk using the current window DPI when available
- add unit tests for DPI setup and Windows dialog initialization order

Before/After:

<img alt="image" src="https://github.com/user-attachments/assets/97e69c36-66bb-4925-9592-d62fa6c6a8ea" />
