### PR TITLE
Feat: configurable dialog title

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,25 @@ ask-human-for-context-mcp/
 - **UI/UX choices**: "Modal dialog or inline editing for this form?"
 - **Technology selection**: "Which CSS framework fits your preferences?"
 
+### Usage with Codex
+
+After installing with `pip`, add the MCP server to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.ask-human-for-context]
+command = "ask-human-for-context-mcp"
+args = ["--transport", "stdio", "--dialog-title", "Codex Needs Input"]
+tool_timeout_sec = 1200
+```
+
+and teach Codex when to use it by adding a rule to `~/.codex/AGENTS.md`, for example:
+
+```md
+If a required fact or preference cannot be discovered locally and a wrong assumption could affect correctness, safety, or design decisions, use `ask-human-for-context` tool before proceeding.
+```
+
+Don't forget to restart a Codex session so it picks up the new MCP server configuration.
+
 ## 🔒 Security & Privacy
 
 - **Local execution**: All dialogs run locally on your machine

--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -84,6 +84,8 @@ class GUIDialogHandler:
         """macOS dialog using osascript with custom Cursor icon."""
         
         # Use the custom Cursor icon from assets folder
+        import os
+
         # Use absolute path to the icon file - more reliable than path calculation
         cursor_icon_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "assets", "cursor-icon.icns")
         

--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import platform
 import subprocess
 from typing import Any, Optional
@@ -15,17 +14,12 @@ import uvicorn
 mcp = FastMCP("ask-human-for-context")
 
 DEFAULT_DIALOG_TITLE = "🤖 Cursor AI Assistant"
-DIALOG_TITLE_ENV_VAR = "ASK_HUMAN_DIALOG_TITLE"
 
 
 def resolve_dialog_title(dialog_title: Optional[str] = None) -> str:
-    """Resolve the dialog title from CLI input, env var, or default."""
+    """Resolve the dialog title from CLI input or default."""
     if dialog_title and dialog_title.strip():
         return dialog_title.strip()
-
-    env_title = os.getenv(DIALOG_TITLE_ENV_VAR, "")
-    if env_title.strip():
-        return env_title.strip()
 
     return DEFAULT_DIALOG_TITLE
 
@@ -444,10 +438,7 @@ def main():
     parser.add_argument(
         '--dialog-title',
         default=None,
-        help=(
-            'Dialog window title. Defaults to the '
-            f'{DIALOG_TITLE_ENV_VAR} environment variable or the built-in title.'
-        ),
+        help='Dialog window title. Defaults to the built-in title.',
     )
     args = parser.parse_args()
 

--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -1,6 +1,7 @@
 import asyncio
-import subprocess
+import os
 import platform
+import subprocess
 from typing import Any, Optional
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
@@ -12,6 +13,21 @@ import uvicorn
 
 # Initialize FastMCP server for User Prompt tools
 mcp = FastMCP("ask-human-for-context")
+
+DEFAULT_DIALOG_TITLE = "🤖 Cursor AI Assistant"
+DIALOG_TITLE_ENV_VAR = "ASK_HUMAN_DIALOG_TITLE"
+
+
+def resolve_dialog_title(dialog_title: Optional[str] = None) -> str:
+    """Resolve the dialog title from CLI input, env var, or default."""
+    if dialog_title and dialog_title.strip():
+        return dialog_title.strip()
+
+    env_title = os.getenv(DIALOG_TITLE_ENV_VAR, "")
+    if env_title.strip():
+        return env_title.strip()
+
+    return DEFAULT_DIALOG_TITLE
 
 
 # Custom exception classes for better error handling (Task 1.4)
@@ -37,9 +53,10 @@ class GUIDialogHandler:
     Falls back to terminal input if GUI is unavailable.
     """
 
-    def __init__(self):
+    def __init__(self, dialog_title: Optional[str] = None):
         """Initialize the dialog handler with platform detection."""
         self.platform = platform.system()
+        self.dialog_title = resolve_dialog_title(dialog_title)
 
     async def get_user_input(self, question: str, timeout: int = 1200) -> Optional[str]:
         """Get user input via native GUI dialog with timeout.
@@ -73,8 +90,6 @@ class GUIDialogHandler:
         """macOS dialog using osascript with custom Cursor icon."""
         
         # Use the custom Cursor icon from assets folder
-        import os
-        
         # Use absolute path to the icon file - more reliable than path calculation
         cursor_icon_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "assets", "cursor-icon.icns")
         
@@ -87,7 +102,7 @@ class GUIDialogHandler:
         script = f'''
         display dialog "{self._escape_for_applescript(question)}" ¬
         default answer "" ¬
-        with title "🤖 Cursor AI Assistant" ¬
+        with title "{self._escape_for_applescript(self.dialog_title)}" ¬
         {icon_clause} ¬
         giving up after {timeout}
         '''
@@ -128,7 +143,7 @@ class GUIDialogHandler:
         
         cmd = [
             "zenity", "--entry",
-            "--title=🤖 Cursor AI Assistant",
+            f"--title={self.dialog_title}",
             f"--text={question}",
             f"--timeout={timeout}",
         ] + icon_args
@@ -153,7 +168,6 @@ class GUIDialogHandler:
         try:
             import tkinter as tk
             from tkinter import simpledialog
-            import os
             
             # Create a simple dialog using tkinter
             root = tk.Tk()
@@ -162,7 +176,7 @@ class GUIDialogHandler:
             # Try to set custom icon from PNG (converted to ICO)
             self._set_windows_icon(root)
             
-            result = simpledialog.askstring("🤖 Cursor AI Assistant", question)
+            result = simpledialog.askstring(self.dialog_title, question)
             root.destroy()
             
             return result
@@ -427,7 +441,18 @@ def main():
     # Port configuration for SSE mode
     parser.add_argument('--port', type=int, default=8080, 
                         help='Port to listen on (for SSE mode)')
+    parser.add_argument(
+        '--dialog-title',
+        default=None,
+        help=(
+            'Dialog window title. Defaults to the '
+            f'{DIALOG_TITLE_ENV_VAR} environment variable or the built-in title.'
+        ),
+    )
     args = parser.parse_args()
+
+    global dialog_handler
+    dialog_handler = GUIDialogHandler(dialog_title=args.dialog_title)
 
     # Launch the server with the selected transport mode
     if args.transport == 'stdio':

--- a/tests/test_dialog_title.py
+++ b/tests/test_dialog_title.py
@@ -5,40 +5,25 @@ import sys
 
 from ask_human_for_context_mcp.server import (
     DEFAULT_DIALOG_TITLE,
-    DIALOG_TITLE_ENV_VAR,
     GUIDialogHandler,
     resolve_dialog_title,
 )
 
 
-def test_resolve_dialog_title_defaults(monkeypatch):
+def test_resolve_dialog_title_defaults():
     """Use the built-in title when no override is present."""
-    monkeypatch.delenv(DIALOG_TITLE_ENV_VAR, raising=False)
-
     assert resolve_dialog_title() == DEFAULT_DIALOG_TITLE
 
 
-def test_resolve_dialog_title_uses_env(monkeypatch):
-    """Use the environment variable when set."""
-    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "My Persistent Title")
-
-    assert resolve_dialog_title() == "My Persistent Title"
-
-
-def test_resolve_dialog_title_prefers_explicit_value(monkeypatch):
-    """Prefer the explicit startup option over the environment variable."""
-    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "Env Title")
-
+def test_resolve_dialog_title_uses_explicit_value():
+    """Use the explicit startup option when provided."""
     assert resolve_dialog_title("CLI Title") == "CLI Title"
 
 
-def test_handler_uses_resolved_dialog_title(monkeypatch):
+def test_handler_uses_resolved_dialog_title():
     """Initialize handlers with the resolved title."""
-    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "Env Title")
-
-    handler = GUIDialogHandler()
-
-    assert handler.dialog_title == "Env Title"
+    assert GUIDialogHandler().dialog_title == DEFAULT_DIALOG_TITLE
+    assert GUIDialogHandler("Custom Title").dialog_title == "Custom Title"
 
 
 def test_help_mentions_dialog_title_option():

--- a/tests/test_dialog_title.py
+++ b/tests/test_dialog_title.py
@@ -1,0 +1,63 @@
+"""Tests for dialog title configuration."""
+import os
+import subprocess
+import sys
+
+from ask_human_for_context_mcp.server import (
+    DEFAULT_DIALOG_TITLE,
+    DIALOG_TITLE_ENV_VAR,
+    GUIDialogHandler,
+    resolve_dialog_title,
+)
+
+
+def test_resolve_dialog_title_defaults(monkeypatch):
+    """Use the built-in title when no override is present."""
+    monkeypatch.delenv(DIALOG_TITLE_ENV_VAR, raising=False)
+
+    assert resolve_dialog_title() == DEFAULT_DIALOG_TITLE
+
+
+def test_resolve_dialog_title_uses_env(monkeypatch):
+    """Use the environment variable when set."""
+    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "My Persistent Title")
+
+    assert resolve_dialog_title() == "My Persistent Title"
+
+
+def test_resolve_dialog_title_prefers_explicit_value(monkeypatch):
+    """Prefer the explicit startup option over the environment variable."""
+    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "Env Title")
+
+    assert resolve_dialog_title("CLI Title") == "CLI Title"
+
+
+def test_handler_uses_resolved_dialog_title(monkeypatch):
+    """Initialize handlers with the resolved title."""
+    monkeypatch.setenv(DIALOG_TITLE_ENV_VAR, "Env Title")
+
+    handler = GUIDialogHandler()
+
+    assert handler.dialog_title == "Env Title"
+
+
+def test_help_mentions_dialog_title_option():
+    """Expose the persistent title option in CLI help."""
+    repo_root = os.path.join(os.path.dirname(__file__), "..")
+    env = os.environ.copy()
+    src_dir = os.path.join(repo_root, "src")
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        src_dir if not existing_pythonpath else src_dir + os.pathsep + existing_pythonpath
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ask_human_for_context_mcp", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "--dialog-title" in result.stdout

--- a/tests/test_macos_dialog.py
+++ b/tests/test_macos_dialog.py
@@ -1,0 +1,37 @@
+"""Tests for macOS dialog behavior."""
+import asyncio
+from unittest.mock import patch
+
+from ask_human_for_context_mcp.server import GUIDialogHandler
+
+
+class FakeProcess:
+    """Minimal async subprocess stub for dialog tests."""
+
+    returncode = 0
+
+    async def communicate(self):
+        """Return a timeout-style AppleScript response."""
+        return (b"gave up:true", b"")
+
+
+def test_macos_dialog_uses_configured_title():
+    """Build the macOS dialog script without missing imports."""
+    captured = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    handler = GUIDialogHandler("Custom Title")
+
+    with patch("asyncio.create_subprocess_exec", new=fake_create_subprocess_exec):
+        result = asyncio.run(handler._macos_dialog("Question?", 10))
+
+    assert result is None
+    assert captured["args"][0] == "osascript"
+    assert captured["args"][1] == "-e"
+    script = captured["args"][2]
+    assert 'with title "Custom Title"' in script
+    assert "giving up after 10" in script


### PR DESCRIPTION
Add a dialog title configuration:

- add a startup-level `--dialog-title` option with a built-in default (the existing "🤖 Cursor AI Assistant")
- use the configured title for macOS, Linux, and Windows dialogs
- add tests for title resolution and CLI help output
- add MCP config examples in the README
