### PR TITLE
Fix configurable dialog timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Your response gets sent back to the AI to continue the workflow.
 
 ### Cross-Platform Native Dialogs
 
-| Platform    | Technology  | Features                              |
-| ----------- | ----------- | ------------------------------------- |
-| **macOS**   | `osascript` | Custom Cursor icon, 90-second timeout |
-| **Linux**   | `zenity`    | Custom window icon, proper styling    |
-| **Windows** | `tkinter`   | Native Windows dialogs                |
+| Platform    | Technology  | Features               |
+| ----------- | ----------- | ---------------------- |
+| **macOS**   | `osascript` | Custom Cursor icon     |
+| **Linux**   | `zenity`    | Custom window icon     |
+| **Windows** | `tkinter`   | Native Windows dialogs |
 
 ### Automatic Fallbacks
 
@@ -223,9 +223,19 @@ ask-human-for-context-mcp --transport sse --host 0.0.0.0 --port 8080
 
 ### Timeout Settings
 
-- **Default timeout**: 90 seconds (1.5 minutes)
-- **Configurable range**: 30 seconds to 2 hours
+- **Default timeout**: 120 seconds (2 minutes)
+- **Configurable**: Use any positive number of seconds
+- **CLI option**: Use `--timeout-seconds` to configure the dialog response timeout
 - **User-friendly**: Shows timeout in minutes for better UX
+
+MCP clients may also enforce their own tool-call timeout. Cursor's MCP
+configuration does not currently document a per-server timeout option, and
+Cursor versions have been reported to time out long-running MCP calls in roughly
+one to two minutes. In clients that do support configuring this, set the
+client-side timeout to at least the same value as `--timeout-seconds`; otherwise
+the client can stop waiting before this server closes the dialog. In Codex,
+configure `tool_timeout_sec = <seconds>` under
+`[mcp_servers.ask-human-for-context]` in `config.toml`.
 
 ## 🔍 Tool Reference
 

--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -1,7 +1,7 @@
 import asyncio
 import subprocess
 import platform
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from mcp.server.sse import SseServerTransport
@@ -12,6 +12,8 @@ import uvicorn
 
 # Initialize FastMCP server for User Prompt tools
 mcp = FastMCP("ask-human-for-context")
+
+DEFAULT_DIALOG_TIMEOUT_SECONDS = 120
 
 
 # Custom exception classes for better error handling (Task 1.4)
@@ -37,16 +39,18 @@ class GUIDialogHandler:
     Falls back to terminal input if GUI is unavailable.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the dialog handler with platform detection."""
         self.platform = platform.system()
 
-    async def get_user_input(self, question: str, timeout: int = 1200) -> Optional[str]:
+    async def get_user_input(
+        self, question: str, timeout: int = DEFAULT_DIALOG_TIMEOUT_SECONDS
+    ) -> Optional[str]:
         """Get user input via native GUI dialog with timeout.
         
         Args:
             question: The question to ask the user
-            timeout: Timeout in seconds (default: 1200 = 20 minutes)
+            timeout: Timeout in seconds
             
         Returns:
             The user's response as a string, or None if timeout/cancelled
@@ -88,7 +92,7 @@ class GUIDialogHandler:
         except Exception:
             pass
 
-    def _configure_windows_tk_scaling(self, root) -> None:
+    def _configure_windows_tk_scaling(self, root: Any) -> None:
         """Match Tk scaling to the current monitor DPI when available."""
         try:
             import ctypes
@@ -188,6 +192,7 @@ class GUIDialogHandler:
 
     async def _windows_dialog(self, question: str, timeout: int) -> Optional[str]:
         """Windows dialog using tkinter with custom Cursor logo."""
+        root = None
         try:
             import tkinter as tk
             from tkinter import simpledialog
@@ -201,13 +206,40 @@ class GUIDialogHandler:
             
             # Try to set custom icon from PNG (converted to ICO)
             self._set_windows_icon(root)
-            
-            result = simpledialog.askstring("🤖 Cursor AI Assistant", question)
-            root.destroy()
-            
-            return result
+
+            return self._ask_windows_string(
+                root,
+                simpledialog,
+                "🤖 Cursor AI Assistant",
+                question,
+                timeout,
+            )
         except Exception:
             return None
+        finally:
+            if root is not None:
+                try:
+                    root.destroy()
+                except Exception:
+                    pass
+
+    def _ask_windows_string(
+        self,
+        root: Any,
+        simpledialog: Any,
+        title: str,
+        question: str,
+        timeout: int,
+    ) -> Optional[str]:
+        """Ask for a Windows string response and close it when timeout expires."""
+        timeout_id = root.after(timeout * 1000, root.destroy)
+        try:
+            return cast(Optional[str], simpledialog.askstring(title, question, parent=root))
+        finally:
+            try:
+                root.after_cancel(timeout_id)
+            except Exception:
+                pass
 
     def _escape_for_applescript(self, text: str) -> str:
         """Escape text for AppleScript."""
@@ -260,7 +292,7 @@ class GUIDialogHandler:
         # Fall back to built-in question icon
         return ["--question"]
 
-    def _set_windows_icon(self, root) -> None:
+    def _set_windows_icon(self, root: Any) -> None:
         """Set icon for Windows tkinter dialog with custom Cursor logo."""
         import os
         
@@ -288,6 +320,7 @@ class GUIDialogHandler:
 
 # Global dialog handler instance
 dialog_handler = GUIDialogHandler()
+dialog_timeout_seconds = DEFAULT_DIALOG_TIMEOUT_SECONDS
 
 
 @mcp.tool()
@@ -319,7 +352,7 @@ async def asking_user_missing_context(
         ValueError: If parameters are invalid or out of acceptable ranges
     """
 
-    timeout_seconds = 90 # 1.5 minutes
+    timeout_seconds = dialog_timeout_seconds
     
     # Parameter validation with clear error messages
     if not question or not isinstance(question, str):
@@ -334,11 +367,8 @@ async def asking_user_missing_context(
     if not isinstance(timeout_seconds, int):
         return "❌ Error: 'timeout_seconds' must be an integer"
     
-    if timeout_seconds < 30:
-        return "❌ Error: 'timeout_seconds' must be at least 30 seconds for usability"
-    
-    if timeout_seconds > 7200:  # 2 hours max
-        return "❌ Error: 'timeout_seconds' cannot exceed 7200 seconds (2 hours) to prevent indefinite hanging"
+    if timeout_seconds < 1:
+        return "❌ Error: 'timeout_seconds' must be at least 1 second"
     
     if not isinstance(context, str):
         return "❌ Error: 'context' must be a string (use empty string if no context needed)"
@@ -445,7 +475,7 @@ def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlett
     )
 
 
-def main():
+def main() -> None:
     """Main entry point for the User Prompt MCP server.
     
     This function serves as the primary entry point when the server is launched
@@ -467,7 +497,19 @@ def main():
     # Port configuration for SSE mode
     parser.add_argument('--port', type=int, default=8080, 
                         help='Port to listen on (for SSE mode)')
+    parser.add_argument(
+        '--timeout-seconds',
+        type=int,
+        default=DEFAULT_DIALOG_TIMEOUT_SECONDS,
+        help=(
+            'Dialog response timeout in seconds. Defaults to '
+            f'{DEFAULT_DIALOG_TIMEOUT_SECONDS} seconds.'
+        ),
+    )
     args = parser.parse_args()
+
+    global dialog_timeout_seconds
+    dialog_timeout_seconds = args.timeout_seconds
 
     # Launch the server with the selected transport mode
     if args.transport == 'stdio':

--- a/src/ask_human_for_context_mcp/server.py
+++ b/src/ask_human_for_context_mcp/server.py
@@ -69,6 +69,44 @@ class GUIDialogHandler:
             # Don't fall back to terminal in MCP context - just report the error
             raise UserPromptError(f"GUI dialog failed: {e}. Ensure osascript (macOS), zenity (Linux), or tkinter (Windows) is available.")
 
+    def _enable_windows_dpi_awareness(self) -> None:
+        """Enable crisp rendering for Windows dialogs on scaled displays."""
+        try:
+            import ctypes
+
+            try:
+                # Prefer per-monitor awareness on modern Windows versions.
+                ctypes.windll.shcore.SetProcessDpiAwareness(2)
+                return
+            except Exception:
+                pass
+
+            try:
+                ctypes.windll.user32.SetProcessDPIAware()
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    def _configure_windows_tk_scaling(self, root) -> None:
+        """Match Tk scaling to the current monitor DPI when available."""
+        try:
+            import ctypes
+
+            dpi = 0
+            try:
+                dpi = ctypes.windll.user32.GetDpiForWindow(root.winfo_id())
+            except Exception:
+                try:
+                    dpi = root.winfo_fpixels("1i")
+                except Exception:
+                    dpi = 0
+
+            if dpi:
+                root.tk.call("tk", "scaling", float(dpi) / 72.0)
+        except Exception:
+            pass
+
     async def _macos_dialog(self, question: str, timeout: int) -> Optional[str]:
         """macOS dialog using osascript with custom Cursor icon."""
         
@@ -153,10 +191,12 @@ class GUIDialogHandler:
         try:
             import tkinter as tk
             from tkinter import simpledialog
-            import os
-            
+
+            self._enable_windows_dpi_awareness()
+
             # Create a simple dialog using tkinter
             root = tk.Tk()
+            self._configure_windows_tk_scaling(root)
             root.withdraw()  # Hide the main window
             
             # Try to set custom icon from PNG (converted to ICO)

--- a/tests/test_dialog_timeout.py
+++ b/tests/test_dialog_timeout.py
@@ -1,0 +1,106 @@
+"""Tests for dialog timeout behavior."""
+
+import asyncio
+import os
+import subprocess
+import sys
+
+from ask_human_for_context_mcp import server
+from ask_human_for_context_mcp.server import (
+    DEFAULT_DIALOG_TIMEOUT_SECONDS,
+    GUIDialogHandler,
+)
+
+
+class FakeRoot:
+    """Minimal Tk root stand-in for timeout scheduling tests."""
+
+    def __init__(self):
+        self.after_calls = []
+        self.after_cancel_calls = []
+        self.destroy_calls = 0
+
+    def after(self, delay_ms, callback):
+        self.after_calls.append((delay_ms, callback))
+        return "timeout-id"
+
+    def after_cancel(self, timeout_id):
+        self.after_cancel_calls.append(timeout_id)
+
+    def destroy(self):
+        self.destroy_calls += 1
+
+
+class FakeSimpleDialog:
+    """Minimal simpledialog stand-in that records askstring arguments."""
+
+    def __init__(self):
+        self.calls = []
+
+    def askstring(self, title, question, parent=None):
+        self.calls.append((title, question, parent))
+        return "typed answer"
+
+
+def test_tool_uses_configured_dialog_timeout(monkeypatch):
+    """Use the configured dialog timeout instead of a hardcoded 90 seconds."""
+
+    class StubDialogHandler:
+        def __init__(self):
+            self.timeout = None
+
+        async def get_user_input(self, question, timeout):
+            self.timeout = timeout
+            return "ok"
+
+    stub = StubDialogHandler()
+    monkeypatch.setattr(server, "dialog_handler", stub)
+    monkeypatch.setattr(server, "dialog_timeout_seconds", 1200)
+
+    result = asyncio.run(server.asking_user_missing_context("Question?"))
+
+    assert result == "✅ User response: ok"
+    assert stub.timeout == 1200
+
+
+def test_windows_string_dialog_schedules_timeout():
+    """Schedule timeout inside Tk so Windows askstring is no longer unbounded."""
+    handler = GUIDialogHandler()
+    root = FakeRoot()
+    simpledialog = FakeSimpleDialog()
+
+    result = handler._ask_windows_string(
+        root,
+        simpledialog,
+        "Title",
+        "Question?",
+        1200,
+    )
+
+    assert result == "typed answer"
+    assert root.after_calls == [(1200 * 1000, root.destroy)]
+    assert root.after_cancel_calls == ["timeout-id"]
+    assert simpledialog.calls == [("Title", "Question?", root)]
+
+
+def test_help_mentions_timeout_option():
+    """Expose the dialog timeout option in CLI help."""
+    repo_root = os.path.join(os.path.dirname(__file__), "..")
+    env = os.environ.copy()
+    src_dir = os.path.join(repo_root, "src")
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        src_dir if not existing_pythonpath else src_dir + os.pathsep + existing_pythonpath
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ask_human_for_context_mcp", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "--timeout-seconds" in result.stdout
+    assert str(DEFAULT_DIALOG_TIMEOUT_SECONDS) in result.stdout

--- a/tests/test_windows_dpi.py
+++ b/tests/test_windows_dpi.py
@@ -66,6 +66,13 @@ def test_windows_dialog_applies_dpi_setup(monkeypatch):
     events = []
 
     class FakeRoot:
+        def after(self, delay_ms, callback):
+            events.append(("after", delay_ms, callback))
+            return "timeout-id"
+
+        def after_cancel(self, timeout_id):
+            events.append(("after-cancel", timeout_id))
+
         def withdraw(self):
             events.append("withdraw")
 
@@ -77,7 +84,10 @@ def test_windows_dialog_applies_dpi_setup(monkeypatch):
     fake_tk = types.ModuleType("tkinter")
     fake_tk.Tk = lambda: fake_root
     fake_tk.simpledialog = types.SimpleNamespace(
-        askstring=lambda title, question: events.append(("askstring", title, question)) or "ok"
+        askstring=lambda title, question, parent=None: events.append(
+            ("askstring", title, question, parent)
+        )
+        or "ok"
     )
 
     monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
@@ -99,6 +109,8 @@ def test_windows_dialog_applies_dpi_setup(monkeypatch):
         ("scale", fake_root),
         "withdraw",
         ("icon", fake_root),
-        ("askstring", "🤖 Cursor AI Assistant", "Question?"),
+        ("after", 10000, fake_root.destroy),
+        ("askstring", "🤖 Cursor AI Assistant", "Question?", fake_root),
+        ("after-cancel", "timeout-id"),
         "destroy",
     ]

--- a/tests/test_windows_dpi.py
+++ b/tests/test_windows_dpi.py
@@ -1,0 +1,104 @@
+"""Tests for Windows-specific DPI handling."""
+import asyncio
+import sys
+import types
+
+from ask_human_for_context_mcp.server import GUIDialogHandler
+
+
+def test_enable_windows_dpi_awareness_prefers_shcore(monkeypatch):
+    """Use per-monitor DPI awareness when the API is available."""
+
+    calls = []
+
+    class FakeShcore:
+        def SetProcessDpiAwareness(self, value):
+            calls.append(("shcore", value))
+
+    class FakeUser32:
+        def SetProcessDPIAware(self):
+            calls.append(("user32", None))
+
+    fake_ctypes = types.SimpleNamespace(
+        windll=types.SimpleNamespace(shcore=FakeShcore(), user32=FakeUser32())
+    )
+
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+    handler = GUIDialogHandler()
+    handler._enable_windows_dpi_awareness()
+
+    assert calls == [("shcore", 2)]
+
+
+def test_configure_windows_tk_scaling_uses_window_dpi(monkeypatch):
+    """Scale Tk based on the monitor DPI reported by Windows."""
+
+    calls = []
+
+    class FakeUser32:
+        def GetDpiForWindow(self, hwnd):
+            assert hwnd == 123
+            return 120
+
+    fake_ctypes = types.SimpleNamespace(
+        windll=types.SimpleNamespace(user32=FakeUser32())
+    )
+
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+    class FakeRoot:
+        def __init__(self):
+            self.tk = types.SimpleNamespace(call=lambda *args: calls.append(args))
+
+        def winfo_id(self):
+            return 123
+
+    handler = GUIDialogHandler()
+    handler._configure_windows_tk_scaling(FakeRoot())
+
+    assert calls == [("tk", "scaling", 120 / 72)]
+
+
+def test_windows_dialog_applies_dpi_setup(monkeypatch):
+    """Initialize DPI handling before showing the Tk dialog."""
+
+    events = []
+
+    class FakeRoot:
+        def withdraw(self):
+            events.append("withdraw")
+
+        def destroy(self):
+            events.append("destroy")
+
+    fake_root = FakeRoot()
+
+    fake_tk = types.ModuleType("tkinter")
+    fake_tk.Tk = lambda: fake_root
+    fake_tk.simpledialog = types.SimpleNamespace(
+        askstring=lambda title, question: events.append(("askstring", title, question)) or "ok"
+    )
+
+    monkeypatch.setitem(sys.modules, "tkinter", fake_tk)
+
+    handler = GUIDialogHandler()
+    monkeypatch.setattr(
+        handler, "_enable_windows_dpi_awareness", lambda: events.append("enable-dpi")
+    )
+    monkeypatch.setattr(
+        handler, "_configure_windows_tk_scaling", lambda root: events.append(("scale", root))
+    )
+    monkeypatch.setattr(handler, "_set_windows_icon", lambda root: events.append(("icon", root)))
+
+    result = asyncio.run(handler._windows_dialog("Question?", 10))
+
+    assert result == "ok"
+    assert events == [
+        "enable-dpi",
+        ("scale", fake_root),
+        "withdraw",
+        ("icon", fake_root),
+        ("askstring", "🤖 Cursor AI Assistant", "Question?"),
+        "destroy",
+    ]


### PR DESCRIPTION
Closes #5

- Increases the default dialog timeout from 90s to 120s.
- Adds `--timeout-seconds` to configure the dialog timeout.
- Fixes Windows ignoring the dialog timeout in the Tkinter dialog path.
- Corrects the timeout docs; the previous "configurable range" was not user-configurable.
